### PR TITLE
Changed the odometry interval to 20ms

### DIFF
--- a/scitos_mira/resources/SCITOS-G5.xml
+++ b/scitos_mira/resources/SCITOS-G5.xml
@@ -7,7 +7,7 @@
 
 		<Modules>
 			<MainControlUnit>
-				<OdometryInterval>100</OdometryInterval>
+				<OdometryInterval>20</OdometryInterval>
 				<Force>80</Force>
 				<RFIDReaderEnabled>true</RFIDReaderEnabled>
 				<FrontLaser>
@@ -46,7 +46,7 @@
 				</if>
 			</MainControlUnit>
 			<Drive>
-				<OdometryInterval>100</OdometryInterval>
+				<OdometryInterval>20</OdometryInterval>
 				<StopOnEmergency>true</StopOnEmergency>
 				<UseTransRotPID>false</UseTransRotPID>
 


### PR DESCRIPTION
Closing issue #41. 
The odometry is sent every 20ms. This is the fastest rate I could achieve. Any faster and the odometry was not published any more. The resulting rate is ~47hz. We tested this odometry rate for quite some time and it does not seem to have any negative effects.
