### PR TITLE
Exception handle for CAN errors

### DIFF
--- a/scitos_mira/src/ScitosHead.cpp
+++ b/scitos_mira/src/ScitosHead.cpp
@@ -1,5 +1,6 @@
 #include "scitos_mira/ScitosHead.h"
 #include <scitos_mira/ScitosG5.h>
+#include <rpc/RPCError.h>
 
 ScitosHead::ScitosHead() : ScitosModule(std::string ("Head")) {
 
@@ -101,13 +102,16 @@ void ScitosHead::publish_joint_state_actual() {
   js.name.push_back(std::string("HeadTilt"));
   js.name.push_back(std::string("EyesPan"));
   js.name.push_back(std::string("EyesTilt"));
-
-  for (std::vector<std::string>::iterator it = js.name.begin(); it != js.name.end(); it++) {
-	value = get_mira_param_(std::string("Head.")+*it);
-	js.position.push_back(::atof(value.c_str()) );
+  try {
+    for (std::vector<std::string>::iterator it = js.name.begin(); it != js.name.end(); it++) {
+	    value = get_mira_param_(std::string("Head.")+*it);
+	    js.position.push_back(::atof(value.c_str()) );
+    }
+    if (joint_state_actual_pub_)
+	    joint_state_actual_pub_.publish(js);
+  } catch (mira::XRPC& e) {
+    ROS_WARN("Missing head angle publication as MIRA parameter error.");
   }
-  if (joint_state_actual_pub_)
-	joint_state_actual_pub_.publish(js);
   
 }
 

--- a/scitos_mira/src/ScitosHead.cpp
+++ b/scitos_mira/src/ScitosHead.cpp
@@ -1,5 +1,6 @@
 #include "scitos_mira/ScitosHead.h"
 #include <scitos_mira/ScitosG5.h>
+#include <rpc/RPCError.h>
 
 ScitosHead::ScitosHead() : ScitosModule(std::string ("Head")) {
 
@@ -101,13 +102,16 @@ void ScitosHead::publish_joint_state_actual() {
   js.name.push_back(std::string("HeadTilt"));
   js.name.push_back(std::string("EyesPan"));
   js.name.push_back(std::string("EyesTilt"));
-
-  for (std::vector<std::string>::iterator it = js.name.begin(); it != js.name.end(); it++) {
-	value = get_mira_param_(std::string("Head.")+*it);
-	js.position.push_back(::atof(value.c_str()) );
+  try {
+	for (std::vector<std::string>::iterator it = js.name.begin(); it != js.name.end(); it++) {
+	  value = get_mira_param_(std::string("Head.")+*it);
+	  js.position.push_back(::atof(value.c_str()) );
+	}
+	if (joint_state_actual_pub_)
+	  joint_state_actual_pub_.publish(js);
+  } catch (mira::XRPC& e) {
+	ROS_WARN("Missing head angle publication as MIRA parameter error.");
   }
-  if (joint_state_actual_pub_)
-	joint_state_actual_pub_.publish(js);
   
 }
 


### PR DESCRIPTION
As detailed in scitos_robot issue 10 (https://github.com/strands-project/scitos_robot/issues/10), and https://github.com/strands-project/scitos_robot/issues/23 when ever the time is changed on the robot while scitos_mira package is up, it crashes. This was most often noticeable when an NTP update occurred, but can also be seen when manually changing the time. This pull request adds try...catch and avoids the driver crashing, but should stay usable.
