### PR TITLE
Important: scitos_mira code bug fix.

### DIFF
--- a/scitos_mira/src/ScitosG5.cpp
+++ b/scitos_mira/src/ScitosG5.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
+#include <ros/spinner.h>
 
 ScitosG5::ScitosG5(std::vector<std::string> modules) : authority_("/", "scitos_ros", mira::Authority::ANONYMOUS),
 					    node_() {
@@ -13,9 +14,9 @@ ScitosG5::ScitosG5(std::vector<std::string> modules) : authority_("/", "scitos_r
     for (std::vector<std::string>::iterator i = modules.begin(); i!=modules.end(); i++) {
       //ROS_INFO_STREAM("Loading module " << *i);
       if (!factory->CheckForModule(*i)) {
-	ROS_ERROR_STREAM("A non existent module was trying to be created. Name=" << *i<<"\n will try to continue without!");
+		ROS_ERROR_STREAM("A non existent module was trying to be created. Name=" << *i<<"\n will try to continue without!");
       } else {
-	modules_.push_back( factory->CreateModule(*i, this) );
+		modules_.push_back( factory->CreateModule(*i, this) );
       }
     }
 
@@ -30,10 +31,10 @@ void ScitosG5::initialize() {
 }
 
 void ScitosG5::spin() {
-  //  ros::spin();
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
   ros::Rate r(5);
   while (ros::ok()) {
-  	ros::spinOnce();
 	for (std::vector< boost::function<void ()> >::iterator i = spin_functions_.begin(); i!=spin_functions_.end(); i++){
 	  (*i)();
 	}


### PR DESCRIPTION
This fixes a bug in the scitos_mira; previously the callbacks for ROS subscriptions coming into the the scitos_mira node were erroneously restricted to 5Hz. Terrible. This means that, for example,  cmd_vel was being processed by the robot in a ridiculously bad way: messages were queued, and every 200ms the queue was cleared and quickly sent to the base. 

This fix processes callbacks in a separate thread to that which publishes some of the topics (most data is published in MIRA threads anyway, just the head angles not).

In testing on Bob, it appears that now the joystick control is more responsive. Goal overshoot from move_base also appears to be reduced. This was a really silly bug that is surprising not to have caused issues earlier; please could people test this version and report anything they notice happening differently. This is really important, we need to check this doesn't introduce strange thread related problems. 
