### PR TITLE
disabling pan-tilt limits in PTU driver

### DIFF
--- a/flir_pantilt_d46/include/ptu46/ptu46_driver.h
+++ b/flir_pantilt_d46/include/ptu46/ptu46_driver.h
@@ -124,6 +124,12 @@ class PTU46 {
         */
         bool SetPosition  (char type, float pos, bool Block = false);
 
+        void SetCheckLimits(bool val);
+
+        bool GetCheckLimits() {
+            return check_limits;
+        }
+
         /**
          * Sets the desired speed in radians/second
          * \param type 'p' or 't'
@@ -177,6 +183,7 @@ class PTU46 {
     protected:
         float tr;	///< tilt resolution (rads/count)
         float pr; 	///< pan resolution (rads/count)
+        bool check_limits;
 
         int fd;		///< serial port descriptor
         struct termios oldtio; ///< old terminal settings

--- a/flir_pantilt_d46/launch/ptu46.launch
+++ b/flir_pantilt_d46/launch/ptu46.launch
@@ -1,6 +1,7 @@
 <launch>
 	<node name="ptu" pkg="flir_pantilt_d46" type="ptu_d46" output="screen">
 		<param name="port" value="/dev/ttyS0"/>
+		<param name="check_limits" value="False"/>
 	</node>
 	<node name="ptu_action_server" pkg="flir_pantilt_d46" type="ptu_action_server.py" output="screen">
 		<remap from="cmd" to="/ptu/cmd"/>

--- a/flir_pantilt_d46/src/ptu46_driver.cc
+++ b/flir_pantilt_d46/src/ptu46_driver.cc
@@ -319,6 +319,14 @@ float PTU46::GetPosition (char type) {
     return strtod (&buffer[2],NULL) * GetResolution(type);
 }
 
+void PTU46::SetCheckLimits(bool val) {
+    check_limits = val;
+    if (check_limits) {
+        Write("le ");
+    } else {
+        Write("ld ");
+    }
+}
 
 // set position in radians
 bool PTU46::SetPosition (char type, float pos, bool Block) {
@@ -329,9 +337,11 @@ bool PTU46::SetPosition (char type, float pos, bool Block) {
     int Count = static_cast<int> (pos/GetResolution(type));
 
     // Check limits
-    if (Count < (type == PTU46_TILT ? TMin : PMin) || Count > (type == PTU46_TILT ? TMax : PMax)) {
-        fprintf (stderr,"Pan Tilt Value out of Range: %c %f(%d) (%d-%d)\n", type, pos, Count, (type == PTU46_TILT ? TMin : PMin),(type == PTU46_TILT ? TMax : PMax));
-        return false;
+    if (check_limits) {
+        if (Count < (type == PTU46_TILT ? TMin : PMin) || Count > (type == PTU46_TILT ? TMax : PMax)) {
+            fprintf (stderr,"Pan Tilt Value out of Range: %c %f(%d) (%d-%d)\n", type, pos, Count, (type == PTU46_TILT ? TMin : PMin),(type == PTU46_TILT ? TMax : PMax));
+            return false;
+        }   
     }
 
     char cmd[16];

--- a/flir_pantilt_d46/src/ptu46_node.cc
+++ b/flir_pantilt_d46/src/ptu46_node.cc
@@ -54,6 +54,7 @@ class PTU46_Node {
         ros::Subscriber m_joint_sub;
         std::string m_pan_joint_name;
         std::string m_tilt_joint_name;
+        bool m_check_limits;
   
 };
 
@@ -66,11 +67,12 @@ PTU46_Node::PTU46_Node(ros::NodeHandle& node_handle)
 	// Get the desired joint names
 	m_node.param<std::string>("pan_joint_name", m_pan_joint_name, std::string("pan"));
 	m_node.param<std::string>("tilt_joint_name", m_tilt_joint_name, std::string("tilt"));
+    m_node.param<bool>("check_limits", m_check_limits, true);
 
 	// Set the values to other nodes can get it even if default used
 	m_node.setParam("pan_joint_name", m_pan_joint_name);
     m_node.setParam("tilt_joint_name", m_tilt_joint_name);
-
+    m_node.setParam("check_limits", m_check_limits);
 }
 
 PTU46_Node::~PTU46_Node() {
@@ -115,6 +117,8 @@ void PTU46_Node::Connect() {
     m_node.setParam("max_pan_speed", m_pantilt->GetMaxSpeed(PTU46_PAN));
     m_node.setParam("pan_step", m_pantilt->GetResolution(PTU46_PAN));
 
+    // set check limits
+    m_pantilt->SetCheckLimits(m_check_limits);
 
     // Publishers : Only publish the most recent reading
     m_joint_pub = m_node.advertise

--- a/flir_pantilt_d46/src/ptu46_node.cc
+++ b/flir_pantilt_d46/src/ptu46_node.cc
@@ -118,6 +118,7 @@ void PTU46_Node::Connect() {
     m_node.setParam("pan_step", m_pantilt->GetResolution(PTU46_PAN));
 
     // set check limits
+    ROS_INFO("check limits:  %d...", m_check_limits);
     m_pantilt->SetCheckLimits(m_check_limits);
 
     // Publishers : Only publish the most recent reading


### PR DESCRIPTION
a new private parameter `check_limits` (boolean) has been introduced which is set to _True_ by default (keeping the default behaviour). With this limit in place, one can only pan up to +/- 2.8 rad. Setting it to false allows to do a full PI pan. This pull request also changes the default in the launch file to _not_ check the limits as we want to turn our head fully reversed.
