### PR TITLE
Using scitos 0.22.7 and prepare for release

### DIFF
--- a/flir_pantilt_d46/CHANGELOG.rst
+++ b/flir_pantilt_d46/CHANGELOG.rst
@@ -1,0 +1,28 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package flir_pantilt_d46
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Added preemption to ptu_action_server
+* Adding machine tags to mira, sick and ptu launch files
+* removed stupid log
+* compelted bug fix after some git troubles
+* pulled in
+* fixed bug
+* Revert "Merge pull request `#54 <https://github.com/strands-project/scitos_drivers/issues/54>`_ from marc-hanheide/hydro-devel"
+  This reverts commit 71e00ddcabb0ee9981d59033a2cb7b505db08ab9, reversing
+  changes made to 51742257dd76556f461efb567828a7d5108bec48. The changes result in
+  the /ptu/state topic being broken. Probably because of line 325 in
+  flir_pantilt_d46/src/ptu46_driver.cc.
+* tested disabling of limits and added to launch file as default
+* first shot on no limits
+* PTU action server using parameterised joint names
+* making PTU unit joint names parameterised
+* updating ptu action server to use joint names
+* make use of joint name to control joints independently. solves `#40 <https://github.com/strands-project/scitos_drivers/issues/40>`_
+* Fixing action server startup
+* rename launch
+* move launch file to own dir
+* prepare to move into scitos_drivers (scitos_mira)
+* Contributors: Bob, Chris Burbridge, Jaime Pulido Fentanes, Marc Hanheide, Rares Ambrus, strands

--- a/flir_pantilt_d46/package.xml
+++ b/flir_pantilt_d46/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>flir_pantilt_d46</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>
      Driver for the FLIR ptu46 pan/tilt, forked from wu_robotics, which was forked from player.
   </description>

--- a/scitos_drivers/CHANGELOG.rst
+++ b/scitos_drivers/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package scitos_drivers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* metapackage dependends on all subpackages
+* rename metapackage to scitos_drivers
+* Contributors: Chris Burbridge

--- a/scitos_mira/CHANGELOG.rst
+++ b/scitos_mira/CHANGELOG.rst
@@ -1,0 +1,36 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package scitos_mira
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* added mira-scitos as dependency
+* added default MIRA_PATH to use with debian package
+* new SCITOS version
+* Adding machine tags to mira, sick and ptu launch files
+* made the SCITOSDriver config file an argument to use udev rules at UOL. Shouldn't effect anyone else
+* Spinning in own thread seperate to publishing thread.
+* Adding exception catching for mira parameter access. Issue `#23 <https://github.com/strands-project/scitos_drivers/issues/23>`_
+* Adding exception catching for mira parameter access. Issue `#23 <https://github.com/strands-project/scitos_drivers/issues/23>`_
+* Closing issue `#41 <https://github.com/strands-project/scitos_drivers/issues/41>`_. Changed the odometry interval to 20ms. This means that the odometry is sent every 20ms. This is the fastest rate I could achieve. Any faster and the odometry was not published any more. The resulting rate is ~47hz. We tested this odometry rate for quite some time and it does not seem to have any negative effects.
+* Update README.md
+* Adding conversion of MIRA debug output to ROS debug messages.
+* Adding msgs dependency
+* Adding bumper to motorstatus topic
+* adding abilty to control eyelids in sync
+* Update CMakeLists.txt
+  including scitos_msgs generation before scitos_mira
+* Adding motor status information publication
+* Fixing boost::bind usage for MIRA callbacks
+* Head lights controllable
+* adding headlight callback
+* Chaning head state publication frequency to 5hz to save CPU
+* Tidy up
+* Making SCITOS modules selectable from launch file.
+* add launch file
+* rename..
+* rename scitos_driver=>scitos_mira
+* rename scitos_driver to scitos_mira
+* rename metapackage to scitos_drivers
+* Made into catkin metapackage
+* Contributors: Chris Burbridge, Christian Dondrup, Jaime Pulido Fentanes, Marc Hanheide, cburbridge

--- a/scitos_mira/CMakeLists.mira
+++ b/scitos_mira/CMakeLists.mira
@@ -3,7 +3,10 @@ message(STATUS "Detecting MIRA root directory")
 
 # Examines each path in MIRA_PATH in order to find the MIRA root directory, which
 # is identified by the file "make/Insource.make"
-set(FindMIRARoot_MIRA_PATH $ENV{MIRA_PATH})
+
+SET(ENV{MIRA_PATH} "$ENV{MIRA_PATH}:/opt/mira-scitos")
+
+set(FindMIRARoot_MIRA_PATH "$ENV{MIRA_PATH}")
 if(UNIX)
 	# note: the "" around "${MIRA_PATH}" are very important !
 	string(REPLACE ":" ";" FindMIRARoot_MIRA_PATH "${FindMIRARoot_MIRA_PATH}")
@@ -14,13 +17,16 @@ set(MIRA_ROOT_DIR "")
 FOREACH(path ${FindMIRARoot_MIRA_PATH})
 	GET_FILENAME_COMPONENT(pathComponent ${path} ABSOLUTE)
 	# strip any trailing slashes from every path in MIRA_PATH env
-	#MESSAGE(STATUS "Examining ${pathComponent}")
+	MESSAGE(STATUS "Examining ${pathComponent}")
 
 	if(EXISTS "${pathComponent}/mira.root")
+		MESSAGE(STATUS "found valid ${pathComponent}")
 		set(FOUND_MIRA_ROOT_DIR 1)
 		set(MIRA_ROOT_DIR ${pathComponent})
 	endif()
 ENDFOREACH(path)
+MESSAGE(STATUS "MIRA_ROOT_DIR=${MIRA_ROOT_DIR}")
+MESSAGE(STATUS "FOUND_MIRA_ROOT_DIR=${FOUND_MIRA_ROOT_DIR}")
 
 IF(FOUND_MIRA_ROOT_DIR)
 	# return the final relative path; must use echo, as cmake does not provide 

--- a/scitos_mira/CMakeLists.txt
+++ b/scitos_mira/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS geometry_msgs roscpp std_msgs sensor_msg
 
 # include cmake file for MIRA
 include(CMakeLists.mira)
-MIRA_REQUIRE_PACKAGE(SCITOS 0.19.0)
+MIRA_REQUIRE_PACKAGE(SCITOS 0.22.7)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/scitos_mira/package.xml
+++ b/scitos_mira/package.xml
@@ -18,6 +18,7 @@
   <build_depend>tf</build_depend>
   <build_depend>scitos_msgs</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>mira-scitos</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>

--- a/scitos_mira/package.xml
+++ b/scitos_mira/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>scitos_mira</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>Driver for Scitos-G5 using the MIRA framework.</description>
 
   <maintainer email="cburbridge@gmail.com">cburbridge</maintainer>


### PR DESCRIPTION
I started working on a release version with a new mira that I debianised as a package called `mira-scitos` which is now available on our Debain server. It's build from here: https://github.com/strands-project/mira_strands. Kudos to @creuther for a little help on this. So, this branch of `scitos_drivers` now depends on `mira-scitos` as a `build_depend`. I have added this to our own rosdep, which however is only being used if people copy https://raw.githubusercontent.com/strands-project/rosdistro/strands-devel/rosdep/sources.list.d/50-strands.list into their `/etc/ros/rosdep/sources.list.d` and run `rosdep update`. I don't thing we can get the mira-scitos key into the official rosdep distribution, as it's not an official package anywhere (yet). But that shouldn't be a big problem. The build farm will resolve this correctly and then the debian package will install it from our repo. 

as this Debian package install MIRA into /opt/mira-scitos I changed the search strategy in here to search this path in addition to the `MIRA_PATH` env variable. So, it now builds without specifically setting those at build time.

Let me know if you consider this all useful or not or if I missed any problems.
