### PR TITLE
Revert "adding scitos_bringup to run dependencies"

### DIFF
--- a/scitos_drivers/package.xml
+++ b/scitos_drivers/package.xml
@@ -18,7 +18,6 @@
   <run_depend>scitos_mira</run_depend>
   <run_depend>sicks300</run_depend>
   <run_depend>flir_pantilt_d46</run_depend>
-  <run_depend>scitos_bringup</run_depend>
 
   <export>
 		<metapackage/>


### PR DESCRIPTION
Reverts strands-project/scitos_drivers#84
