### PR TITLE
Make magnetic barrier a more secure stop.

### DIFF
--- a/scitos_mira/include/scitos_mira/ScitosDrive.h
+++ b/scitos_mira/include/scitos_mira/ScitosDrive.h
@@ -16,11 +16,13 @@
 #include "scitos_mira/ScitosModule.h"
 #include <scitos_msgs/ResetMotorStop.h>
 #include <scitos_msgs/ResetOdometry.h>
+#include <scitos_msgs/ResetBarrierStop.h>
 #include <scitos_msgs/EmergencyStop.h>
 #include <scitos_msgs/EnableMotors.h>
 #include <scitos_msgs/MotorStatus.h>
 #include <scitos_msgs/ChangeForce.h>
 #include <scitos_msgs/EnableRfid.h>
+#include <scitos_msgs/BarrierStatus.h>
 #include <utils/Time.h>
 
 class ScitosDrive: public ScitosModule {
@@ -46,7 +48,8 @@ public:
 	bool enable_motors(scitos_msgs::EnableMotors::Request  &req, scitos_msgs::EnableMotors::Response &res);
 	bool change_force(scitos_msgs::ChangeForce::Request  &req, scitos_msgs::ChangeForce::Response &res);
 	bool enable_rfid(scitos_msgs::EnableRfid::Request  &req, scitos_msgs::EnableRfid::Response &res);
-
+	bool reset_barrier_stop(scitos_msgs::ResetBarrierStop::Request  &req, scitos_msgs::ResetBarrierStop::Response &res);
+	void publish_barrier_status();
 private:
 	ScitosDrive();
 	ros::Subscriber cmd_vel_subscriber_;
@@ -63,7 +66,9 @@ private:
 	ros::ServiceServer enable_motors_service_;
 	ros::ServiceServer change_force_service_;
 	ros::ServiceServer enable_rfid_service_;
-	mira::Time last_magnetic_barrier_detection;
+	ros::ServiceServer reset_barrier_stop_service_;
+
+	scitos_msgs::BarrierStatus barrier_status_;
 };
 
 #endif

--- a/scitos_mira/package.xml
+++ b/scitos_mira/package.xml
@@ -4,9 +4,9 @@
   <version>0.0.11</version>
   <description>Driver for Scitos-G5 using the MIRA framework.</description>
 
-  <maintainer email="cburbridge@gmail.com">cburbridge</maintainer>
+  <maintainer email="cburbridge@gmail.com">Chris Burbridge</maintainer>
   
-  <author email="cburbridge@gmail.com">cburbridge</author>
+  <author email="cburbridge@gmail.com">Chris Burbridge</author>
   <author email="tkrajnik@lincoln.ac.uk">Tom Krajnik</author>
 
   <license>GPL</license>


### PR DESCRIPTION
This PR changes the magnetic barrier code in the following way:
- the detection of the magnetic barrier latches a software cut-out, preventing motor commands being processed, in adition to the lowlevel motor stop
- a topic `/barrier_status` of type `scitos_msgs/BarrierStatus` gives the current condition of the "barrier stop", akin to the "motor stop". If true, the robot will ignore any velocity commands. It also gives the time stamp of the last magnetic strip detection and the current timestamp. This is published at 5Hz in the main loop.
- provides a service `/reset_barrier_stop` to re-enable the drive commands, akin to `/reset_motortop`. If the barrier has been detected, the robot will not move until this is called regardless of the motor stop status.
- moves magnetic barrier related code out of the bumper callback. The (non `/motor_status`) bumper data coming from MIRA is a mix of motor stop and bumper pressed so this topic may be removed in the future.
