### PR TITLE
[flir_pantilt_d46] Velocity control mode

### DIFF
--- a/flir_pantilt_d46/CMakeLists.txt
+++ b/flir_pantilt_d46/CMakeLists.txt
@@ -4,7 +4,7 @@ project(flir_pantilt_d46)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs diagnostic_updater roscpp rospy sensor_msgs std_msgs)
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs diagnostic_updater roscpp rospy sensor_msgs std_msgs message_generation)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -28,11 +28,10 @@ catkin_python_setup()
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  SetControlMode.srv
+)
 
 # Actions
 add_action_files(

--- a/flir_pantilt_d46/package.xml
+++ b/flir_pantilt_d46/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>actionlib</build_depend>
-
+  <build_depend>message_generation</build_depend>
   <build_depend>actionlib_msgs</build_depend>
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>roscpp</build_depend>
@@ -30,7 +30,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
-
+  <run_depend>message_runtime</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/flir_pantilt_d46/src/ptu46_node.cc
+++ b/flir_pantilt_d46/src/ptu46_node.cc
@@ -148,7 +148,7 @@ void PTU46_Node::Connect() {
     m_joint_sub = m_node.subscribe
                   <sensor_msgs::JointState>("cmd", 1, &PTU46_Node::SetGoal, this);
 
-	m_control_mode_srv = m_node.advertiseService("set_conrol_mode",
+	m_control_mode_srv = m_node.advertiseService("set_control_mode",
 												 &PTU46_Node::SetControlModeSrv, this);
 
 }

--- a/flir_pantilt_d46/srv/SetControlMode.srv
+++ b/flir_pantilt_d46/srv/SetControlMode.srv
@@ -1,0 +1,5 @@
+int8 POSITION_CONTROL=0
+int8 VELOCITY_CONTROL=1
+int8 control_type
+---
+bool success


### PR DESCRIPTION
This adds a service to the PTU node that enables velocity control. When in velocity control mode the 'position' field of the JointState command is ignored, only the 'velocity' field is used. The PTU will drive with the supplied velocity up to the joint limit.
