### PR TITLE
Add service to reset/calibrate PTU.

### DIFF
--- a/flir_pantilt_d46/CMakeLists.txt
+++ b/flir_pantilt_d46/CMakeLists.txt
@@ -4,7 +4,7 @@ project(flir_pantilt_d46)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs diagnostic_updater roscpp rospy sensor_msgs std_msgs)
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs diagnostic_updater roscpp rospy sensor_msgs std_msgs std_srvs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/flir_pantilt_d46/include/ptu46/ptu46_driver.h
+++ b/flir_pantilt_d46/include/ptu46/ptu46_driver.h
@@ -2,6 +2,7 @@
 #define _PTU46_DRIVER_H_
 
 #include <termios.h>
+#include <boost/thread/mutex.hpp>
 
 // serial defines
 #define PTU46_DEFAULT_BAUD 9600
@@ -151,6 +152,13 @@ class PTU46 {
          */
         char GetMode ();
 
+	/**
+	 * Reset the PTU unit, performing a calibaration.
+	 * Blocks until the reset is complete. 
+	 * \return true if success, otherwise false.
+	 */
+	bool Reset ();
+
     private:
         /** Get radian/count resolution
          * \param type 'p' or 't'
@@ -179,6 +187,8 @@ class PTU46 {
         int TSMax;	///< Max Tilt Speed in Counts/second
         int PSMin;	///< Min Pan Speed in Counts/second
         int PSMax;	///< Max Pan Speed in Counts/second
+
+	boost::mutex io_mutex;
 
     protected:
         float tr;	///< tilt resolution (rads/count)

--- a/flir_pantilt_d46/package.xml
+++ b/flir_pantilt_d46/package.xml
@@ -22,12 +22,14 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
 

--- a/flir_pantilt_d46/src/ptu46_node.cc
+++ b/flir_pantilt_d46/src/ptu46_node.cc
@@ -57,6 +57,7 @@ class PTU46_Node {
         ros::Subscriber m_joint_sub;
         ros::ServiceServer m_reset_srv;
         ros::Subscriber m_joint_sub_vel;  
+        ros::ServiceServer m_reset_srv;
         std::string m_pan_joint_name;
         std::string m_tilt_joint_name;
         bool m_check_limits;


### PR DESCRIPTION
This adds a new service `/ptu/reset` of type `std_srvs/Empty` to the PTU node. The service resets the PTU in the same way as a power off/on, moving up,down,left,right to get the limits and calibrate the position sensing. The service call returns once the calibration routine is over. During execution any commands on `/ptu/cmd` will be ignored and the `/ptu/state` topic will not be published. After execution the PTU will be at the zero position.

This service is mostly only useful if you screw up the position sensing by driving past the limits.
