### PR TITLE
[scitos_mira] Turn rear laser EBC port on by default and accessible in cfg

### DIFF
--- a/scitos_mira/cfg/EBCParameters.cfg
+++ b/scitos_mira/cfg/EBCParameters.cfg
@@ -18,7 +18,8 @@ bool_params = [
 	("Port0_24V_Enabled", "Is 24V enabled at port 0", True),
 	("Port1_5V_Enabled",  "Is 5V enabled at port 1", True),
 	("Port1_12V_Enabled", "Is 12V enabled at port 1", True),
-	("Port1_24V_Enabled", "Is 24V enabled at port 1", True)
+	("Port1_24V_Enabled", "Is 24V enabled at port 1", True),
+    ("RearLaser_Enabled", "Is RearLaser (Magnetic Sensor) enabled", True)
 ]
 
 float_params = [

--- a/scitos_mira/cfg/EBCParameters.cfg
+++ b/scitos_mira/cfg/EBCParameters.cfg
@@ -19,7 +19,7 @@ bool_params = [
 	("Port1_5V_Enabled",  "Is 5V enabled at port 1", True),
 	("Port1_12V_Enabled", "Is 12V enabled at port 1", True),
 	("Port1_24V_Enabled", "Is 24V enabled at port 1", True),
-    ("RearLaser_Enabled", "Is RearLaser (Magnetic Sensor) enabled", True)
+	("RearLaser_Enabled", "Is RearLaser (Magnetic Sensor) enabled", True)
 ]
 
 float_params = [

--- a/scitos_mira/src/ScitosEBC.cpp
+++ b/scitos_mira/src/ScitosEBC.cpp
@@ -70,4 +70,10 @@ void ScitosEBC::reconfigure_callback( scitos_mira::EBCParametersConfig& config, 
 	  set_mira_param_("EBC7.Port1_24V.Enabled","false");
 	set_mira_param_("EBC7.Port1_24V.MaxCurrent",std::to_string(config.Port1_24V_MaxCurrent));
 
+    // Rear Laser
+    if (config.RearLaser_Enabled)
+	  set_mira_param_("MainControlUnit.RearLaser.Enabled","true");
+	else
+	  set_mira_param_("MainControlUnit.RearLaser.Enabled","false");
+
 }


### PR DESCRIPTION
We just tested this on the robot and seems to work. @cburbridge can you see if you're OK with this?
