### PR TITLE
Make magnetic barrier enable a normal parameter.

### DIFF
--- a/scitos_mira/cfg/EBCParameters.cfg
+++ b/scitos_mira/cfg/EBCParameters.cfg
@@ -19,7 +19,6 @@ bool_params = [
 	("Port1_5V_Enabled",  "Is 5V enabled at port 1", True),
 	("Port1_12V_Enabled", "Is 12V enabled at port 1", True),
 	("Port1_24V_Enabled", "Is 24V enabled at port 1", True),
-	("RearLaser_Enabled", "Is RearLaser (Magnetic Sensor) enabled", True)
 ]
 
 float_params = [

--- a/scitos_mira/launch/scitos_mira.launch
+++ b/scitos_mira/launch/scitos_mira.launch
@@ -3,6 +3,9 @@
 	<!-- scitos_modules argument; must be a space seperated list of hardware modules to load -->
 	<arg name="SCITOS_MODULES" default="Drive Charger EBC Display Head"/>
 	<arg name="SCITOS_CONFIG" default="$(find scitos_mira)/resources/SCITOSDriver.xml"/>
+	<!-- BARRIER_ENABLED should be set to true to enable the magnetic strip detector to cut out
+	the motors. If set to false, then magnetic safety barriers will have no effect. -->
+	<arg name="BARRIER_ENABLED" default="true"/>
 
 	<!-- Remote Launching -->
     <arg name="machine" default="localhost"/>
@@ -13,6 +16,7 @@
 	<node pkg="scitos_mira" type="scitos_node" name="scitos_node" output="screen" respawn="true">
 		<param name="config_file" value="$(arg SCITOS_CONFIG)" type="string"/>
 		<param name="scitos_modules" value="$(arg SCITOS_MODULES)" />
+		<param name="magnetic_barrier_enabled" value="$(arg BARRIER_ENABLED)" />
 	</node>
 
 </launch>

--- a/scitos_mira/src/ScitosDrive.cpp
+++ b/scitos_mira/src/ScitosDrive.cpp
@@ -48,6 +48,16 @@ void ScitosDrive::initialize() {
   enable_rfid_service_ = robot_->getRosNode().advertiseService("/enable_rfid", &ScitosDrive::enable_rfid, this);
   reset_barrier_stop_service_ = robot_->getRosNode().advertiseService("/reset_barrier_stop", &ScitosDrive::reset_barrier_stop, this);
 
+  bool magnetic_barrier_enabled = true;
+  ros::param::param("~magnetic_barrier_enabled", magnetic_barrier_enabled, magnetic_barrier_enabled);
+  if (magnetic_barrier_enabled) {
+    set_mira_param_("MainControlUnit.RearLaser.Enabled", "true");
+  }  else {
+    ROS_WARN("Magnetic barrier motor stop not enabled.");
+    set_mira_param_("MainControlUnit.RearLaser.Enabled", "false");
+  }
+
+
   barrier_status_.barrier_stopped = false;
   barrier_status_.last_detection_stamp = ros::Time(0);
   robot_->registerSpinFunction(boost::bind(&ScitosDrive::publish_barrier_status, this));

--- a/scitos_mira/src/ScitosEBC.cpp
+++ b/scitos_mira/src/ScitosEBC.cpp
@@ -70,10 +70,4 @@ void ScitosEBC::reconfigure_callback( scitos_mira::EBCParametersConfig& config, 
 	  set_mira_param_("EBC7.Port1_24V.Enabled","false");
 	set_mira_param_("EBC7.Port1_24V.MaxCurrent",std::to_string(config.Port1_24V_MaxCurrent));
 
-    // Rear Laser
-    if (config.RearLaser_Enabled)
-	  set_mira_param_("MainControlUnit.RearLaser.Enabled","true");
-	else
-	  set_mira_param_("MainControlUnit.RearLaser.Enabled","false");
-
 }


### PR DESCRIPTION
This removes the dynamic reconfigure option to enable/disable the magnetic barrier stop, and introduces a new private parameter ~magnetic_barrier_enabled for controlling the status at startup. This is set in the launch file to have a value of true by default so the behaviour  of the robot is no different when the PR is merged.

The barrier can still be enabled/disabled at runtime using the `/enable_rfid` service call as before.

I will create another PR for strands_bringup that passes the parameter down from strands_robot.launch.
