### PR TITLE
Don't reset odometry on start.

### DIFF
--- a/scitos_mira/resources/SCITOS-G5.xml
+++ b/scitos_mira/resources/SCITOS-G5.xml
@@ -8,6 +8,7 @@
 		<Modules>
 			<MainControlUnit>
 				<OdometryInterval>50</OdometryInterval>
+				<ResetOdometryOnStart>false</ResetOdometryOnStart>
 				<Force>80</Force>
 				<RFIDReaderEnabled>true</RFIDReaderEnabled>
 				<FrontLaser>


### PR DESCRIPTION
Allows restarting the mira interface node without messing up amcl.
