### PR TITLE
Add service to get persistent charger error log.

### DIFF
--- a/scitos_mira/include/scitos_mira/ScitosCharger.h
+++ b/scitos_mira/include/scitos_mira/ScitosCharger.h
@@ -15,6 +15,7 @@
 #include <robot/BatteryState.h>
 #include <dynamic_reconfigure/server.h>
 #include <scitos_mira/ChargerParametersConfig.h>
+#include <scitos_msgs/SavePersistentErrors.h>
 
 class ScitosCharger: public ScitosModule {
 public:
@@ -27,11 +28,14 @@ public:
 	void battery_data_callback(mira::ChannelRead<mira::robot::BatteryState> data);
 	void charger_status_callback(mira::ChannelRead<uint8> data);
 	void reconfigure_callback(scitos_mira::ChargerParametersConfig &config, uint32_t level);
+	bool save_persistent_errors(scitos_msgs::SavePersistentErrors::Request  &req, scitos_msgs::SavePersistentErrors::Response &res);
+
 private:
 
 	ScitosCharger();
 	ros::Publisher battery_pub_;
 	ros::Publisher charger_pub_;
+	ros::ServiceServer save_persistent_errors_service_;
 	dynamic_reconfigure::Server<scitos_mira::ChargerParametersConfig> reconfigure_srv_;
 };
 


### PR DESCRIPTION
This adds a new service to the scitos node: `/charger/save_persistent_errors`. This service takes a std::string filename as the parameter, and saves the robots internal error log to that file using the MIRA service savePersistentErrors. Usage:

```
strands@betty:~$ rosservice call /charger/save_persistent_errors "filename: '/tmp/errors.txt'" 
```

example output:

```
[
    {
        "Accu24VVoltage" : 22.57400131225586,
        "AccuCurrent" : 1.876000046730042,
        "AccuCurrentExternalCharger" : 0.0,
        "AccuCurrentInternalCharger" : 0.0,
        "AccuLoadVoltage" : 22.24200057983398,
        "AccuMaxCurrent" : 1.896000146865845,
        "AccuMinVoltage" : 22.06600189208984,
        "AccuStatus" : 2,
        "AccuVoltageExternalCharger" : 3.105000257492065,
        "AccuVoltageInternalCharger" : 0.004000000189989805,
        "CellVoltage" : [ 2.94100022315979, 2.928000211715698, 2.722000122070312, 2.776000022888184, 3.049000263214111, 2.790000200271606, 2.872000217437744, 2.496000051498413 ],
        "Code" : 16843011,
        "CurrentVelocity" : {
            "Phi" : 0.0,
            "X" : 0.0,
            "Y" : 0.0
        },
        "CurrentVelocityTime" : 56532,
        "EmbeddedPCStatus" : 15,
        "EmergencyCode" : 36864,
        "ErrorRegister" : 128,
        "GlobalCounter" : 15195350,
        "Message" : "Cell undervoltage",
        "NodeID" : 1,
        "PowerupCounter" : 5,
        "RequestedVelocity" : {
            "Phi" : 0.0,
            "X" : 0.0,
            "Y" : 0.0
        },
        "RequestedVelocityTime" : 35535,
        "Type" : 1,
        "UnixTime" : 1422172242000000000
    },
   ....
```

These error logs are often requested by MetraLabs, so this just avoids the need to stop the robot and run miracenter manually.
